### PR TITLE
NFC: Update readme to install react router

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Install [Material UI](https://mui.com/)
 npm install @mui/material @emotion/react @emotion/styled
 ```
 
+Install React Router
+```bash
+npm install react-router-dom
+```
+
 ### <a name="upgrade-npm"></a>Upgrading npm
 
 Install the new package with curl.


### PR DESCRIPTION
This commit adds a command to install react-router-dom, which enables the usage of the <Link> component. This component allows for routing to other pages in the website.

Ticket: NAUR-7