### PR TITLE
updated hamburger menu placement

### DIFF
--- a/naurffxiv/src/components/NavBar/NavBar.js
+++ b/naurffxiv/src/components/NavBar/NavBar.js
@@ -76,19 +76,6 @@ export default function NavBar() {
               ))}
             </Typography>
           </Box>
-          {/* Hamburger menu*/}
-          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-            <IconButton
-              size="large"
-              aria-label="icon-button"
-              aria-controls="menu-appbar"
-              aria-haspopup="true"
-              onClick={handleOpenNavMenu}
-              color="inherit"
-            >
-              <MenuIcon />
-            </IconButton>
-          </Box>
           <Box sx={{ px: 1 }}>
             <IconButton size="small">
               <Link href="/">
@@ -113,9 +100,22 @@ export default function NavBar() {
               </Link>
             </IconButton>
           </Box>
-          <Box sx={{ px: 1 }}>
-            <ThemeSwitch checked={isDarkMode} onChange={toggleTheme} />
+            {/* Hamburger menu*/}
+          <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+            <IconButton
+              size="large"
+              aria-label="icon-button"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={handleOpenNavMenu}
+              color="inherit"
+            >
+              <MenuIcon />
+            </IconButton>
           </Box>
+          {/* <Box sx={{ px: 1 }}>
+            <ThemeSwitch checked={isDarkMode} onChange={toggleTheme} />
+          </Box> */}
           {/* Mobile menu */}
           <Menu
               disableScrollLock

--- a/naurffxiv/src/components/NavBar/NavBar.js
+++ b/naurffxiv/src/components/NavBar/NavBar.js
@@ -100,7 +100,7 @@ export default function NavBar() {
               </Link>
             </IconButton>
           </Box>
-            {/* Hamburger menu*/}
+          {/* Hamburger menu*/}
           <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
             <IconButton
               size="large"
@@ -113,6 +113,9 @@ export default function NavBar() {
               <MenuIcon />
             </IconButton>
           </Box>
+          {/* Button for dark/light theme is commented out for now as design decisions,
+          needs to be completely removed along with the code supporting the functionality
+          when the decision to remove the button is final */}
           {/* <Box sx={{ px: 1 }}>
             <ThemeSwitch checked={isDarkMode} onChange={toggleTheme} />
           </Box> */}


### PR DESCRIPTION
Ticket: NAUR-62
- Removed theme switch functionality from desktop and narrow resolutions
- Repositioned hamburger menu to replace theme switch location on narrow resolutions

Note:
Running `make start` required installation of the "remark-frontmatter" npm package to run site locally
Theme switch code remains in the codebase for potential future use - only the button has been removed from the layout



![image](https://github.com/user-attachments/assets/f58be653-3557-48f2-a279-d227abec44d5)
