### PR TITLE
Fix pixel line bug and add urls to homepage cards

### DIFF
--- a/naurffxiv/src/app/constants.js
+++ b/naurffxiv/src/app/constants.js
@@ -85,12 +85,12 @@ export const getMenuProps = (anchorEl, open, handleClose, isMobile) => ({
 });
 
 export const slides = [
-  {id: 1, url: '/', src: images.Bahamut, alt: 'Bahamut', title: 'The Unending Coil of Bahamut' },
-  {id: 2, url: '/', src: images.Ultima, alt: 'Ultima', title: 'The Weapon\'s Refrain' },
-  {id: 3, url: '/', src: images.Alexander, alt: 'Alexander', title: 'The Epic of Alexander' },
-  {id: 4, url: '/', src: images.Thordan, alt: 'Thordan', title: 'Dragonsong\'s Reprise' },
-  {id: 5, url: '/', src: images.Omega, alt: 'Omega', title: 'The Omega Protocol' },
-  {id: 6, url: '/', src: images.Pandora, alt: 'Pandora', title: 'Futures Rewritten' },
+  {id: 1, url: '/ultimates/ucob', src: images.Bahamut, alt: 'Bahamut', title: 'The Unending Coil of Bahamut' },
+  {id: 2, url: '/ultimates/uwu', src: images.Ultima, alt: 'Ultima', title: 'The Weapon\'s Refrain' },
+  {id: 3, url: '/ultimates/tea', src: images.Alexander, alt: 'Alexander', title: 'The Epic of Alexander' },
+  {id: 4, url: '/ultimates/dsr', src: images.Thordan, alt: 'Thordan', title: 'Dragonsong\'s Reprise' },
+  {id: 5, url: '/ultimates/top', src: images.Omega, alt: 'Omega', title: 'The Omega Protocol' },
+  {id: 6, url: '/ultimates/fru', src: images.Pandora, alt: 'Pandora', title: 'Futures Rewritten' },
 ];
 
 export const linksUltimates = [

--- a/naurffxiv/src/components/Homepage/Hero.js
+++ b/naurffxiv/src/components/Homepage/Hero.js
@@ -4,7 +4,7 @@ import { icons } from "@/app/assets"
 export default function Header() {
     return (
       <div className="grid min-w-full md:grid-cols-[40%_60%] xl:grid-cols-[45%_55%]">
-        <div className="px-5 xl:pr-0 bg-center bg-header-default md:bg-header-gradient">
+        <div className="px-5 xl:pr-0 bg-center bg-header-default md:bg-header-gradient md:bg-left">
           <div className="grid mx-auto py-16 gap-y-3 max-w-prose md:gap-y-6 xl:float-right">
             <h1 className="text-4xl xl:text-6xl font-bold">NAUR</h1>
             <h3 className="text-lg/8 xl:text-2xl/10">
@@ -22,7 +22,10 @@ export default function Header() {
             </a>
           </div>
         </div>
-        <div className="hidden md:block bg-header-wide bg-cover bg-center h-60 md:h-auto"/>
+        <div className="hidden md:block bg-header-wide bg-cover bg-center h-60 md:h-auto">
+          <div className="min-h-full bg-header-wide-gradient">
+          </div>
+        </div>
       </div>
     )
 }

--- a/naurffxiv/tailwind.config.js
+++ b/naurffxiv/tailwind.config.js
@@ -12,7 +12,9 @@ module.exports = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
         "header-wide":
-          "linear-gradient(to right, rgba(26, 25, 43, 100%) 0%, rgba(26, 25, 43, 0%) 20%), url('/images/server-header.png')",
+          "url('/images/server-header.png')",
+        "header-wide-gradient":
+          "linear-gradient(to right, rgba(26, 25, 43, 100%) 0%, rgba(26, 25, 43, 0%) 20%)",
         "header-default":
           "linear-gradient(rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 100%), url('/images/server-header.png')",
         "header-gradient":


### PR DESCRIPTION
Ticket: NAUR-90
Ticket: NAUR-92
![image](https://github.com/user-attachments/assets/bd697033-2d1e-45f2-ab74-3b6eab4900e3)
There's a single pixel line on certain browsers due to the way `background-position: center;` is implemented on different browsers (i think), I've made the linear gradient a separate div from the image to work around this
I've also added urls to the cards in the homepage