### PR TITLE
Simplify Markdown logic

### DIFF
--- a/naurffxiv/package-lock.json
+++ b/naurffxiv/package-lock.json
@@ -26,6 +26,7 @@
         "rehype-img-size": "^1.0.1",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
+        "remark-mdx-frontmatter": "^5.0.0",
         "remark-toc": "^9.0.0"
       },
       "devDependencies": {
@@ -6994,6 +6995,47 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-mdx-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-mdx-frontmatter/-/remark-mdx-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-kI75pshe27TM71R+0iX7C3p4MbGMdygkvSbrk1WYSar88WAwR2JfQilofcDGgDNFAWUo5IwTPyq9XvGpifTwqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-value-to-estree": "^3.0.0",
+        "toml": "^3.0.0",
+        "unified": "^11.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/remark-mdx-frontmatter/node_modules/estree-util-value-to-estree": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.2.tgz",
+      "integrity": "sha512-hYH1aSvQI63Cvq3T3loaem6LW4u72F187zW4FHpTrReJSm6W66vYTFNO1vH/chmcOulp1HlAj1pxn8Ag0oXI5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/remark-mdx-frontmatter/node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -7929,6 +7971,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/naurffxiv/package.json
+++ b/naurffxiv/package.json
@@ -27,6 +27,7 @@
     "rehype-img-size": "^1.0.1",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
+    "remark-mdx-frontmatter": "^5.0.0",
     "remark-toc": "^9.0.0"
   },
   "devDependencies": {

--- a/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
+++ b/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
@@ -1,5 +1,61 @@
 import path from 'path';
 import { promises as fs, readdirSync } from 'fs';
+import * as runtime from "react/jsx-runtime";
+import { evaluate } from '@mdx-js/mdx'
+import { cache } from 'react';
+
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
+import rehypeImgSize from 'rehype-img-size';
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeExtractToc from "@stefanprobst/rehype-extract-toc";
+import rehypeExtractTocExport from "@stefanprobst/rehype-extract-toc/mdx";
+
+// process each mdx file and cache it
+export const processMdx = cache(async (filepath) => {
+    const rawmdx = await fs.readFile(filepath, 'utf-8')
+
+    // process mdx
+    const processedMdx = await evaluate(rawmdx, {
+        ...runtime,
+        baseUrl: import.meta.url,
+        remarkPlugins: [
+            remarkFrontmatter,
+            remarkMdxFrontmatter
+        ],
+        rehypePlugins: [
+            rehypeSlug,
+            [
+                rehypeAutolinkHeadings,
+                {
+                behavior: 'append',
+                properties: {
+                    ariaHidden: false,
+                    tabIndex: -1,
+                    className: 'hash-link',
+                },
+                },
+            ],
+            [rehypeImgSize, { dir: 'public' }],
+            rehypeExtractToc,
+            [rehypeExtractTocExport, {name: "toc"}]
+        ]
+    })
+    
+    return processedMdx
+})
+
+// resolves mdx filepath from slug and returns the processed file
+export async function getProcessedMdxFromParams(params) {
+    const {difficulty} = params
+    const mdxDir = path.join(getMdxDir(), difficulty) 
+
+    const filepath = await findMdxFilepath(params)
+    if (!filepath) return {error: `file at ${filepath} not found`}
+
+    return await processMdx(path.join(mdxDir, filepath))
+}
 
 export function getMdxDir(subfolders = []) {
     return path.join(process.cwd(), 'src', 'markdown', ...subfolders)

--- a/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
+++ b/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
@@ -42,7 +42,7 @@ export const processMdx = cache(async (filepath) => {
             [rehypeExtractTocExport, {name: "toc"}]
         ]
     })
-    
+
     return processedMdx
 })
 
@@ -98,12 +98,18 @@ async function findMdxShared(params, subfunc) {
         let diff = dirname === "." ? goalPath : goalPath.substring(dirname.length + 1)
         if (diff.length == 0) diff = "."
         const pathArray = diff === "." ? [] : diff.split(path.sep)
-        const meta = JSON.parse(await fs.readFile(path.join(mdxDir, metaFile), {encoding: 'utf-8'}))
+        const meta = await readAndParseJson(path.join(mdxDir, metaFile), {encoding: 'utf-8'})
         const ret = subfunc(meta, pathArray, dirname)
         if (ret) return ret
     }
     return 
 }
+
+// read, parse, and cache a processed json file
+export const readAndParseJson = cache(async (filepath) => {
+    const file = await fs.readFile(filepath)
+    return JSON.parse(file, {encoding: 'utf-8'})
+})
 
 // gets the filepath of a specific mdx file
 export async function findMdxFilepath(params) {

--- a/naurffxiv/src/app/[difficulty]/[[...slug]]/index.js
+++ b/naurffxiv/src/app/[difficulty]/[[...slug]]/index.js
@@ -4,7 +4,7 @@ import React from "react";
 import TableOfContents from "@/components/Mdx/TableOfContents";
 import QuickLinks from "@/components/Mdx/QuickLinks";
 
-const MDXPage = ({params: content, toc, metadata, slug}) => {
+const MDXPage = ({children, toc, metadata, slug}) => {
     return (
         <MdxLayout>
             <div className="grid grid-cols-1 lg:grid-cols-[90ch_1fr] xl:grid-cols-[1fr_90ch_1fr] max-w-screen-2xl mx-auto py-6">
@@ -13,7 +13,7 @@ const MDXPage = ({params: content, toc, metadata, slug}) => {
                 </div>
 
                 <article className="max-w-[90ch] prose prose-invert m-auto mx-6">
-                    {content}
+                    {children}
                 </article>
 
                 <div className="prose prose-invert top-[5.5rem] self-start hidden lg:block sticky">

--- a/naurffxiv/src/app/[difficulty]/[[...slug]]/page.js
+++ b/naurffxiv/src/app/[difficulty]/[[...slug]]/page.js
@@ -1,87 +1,25 @@
-import { compileMDX } from 'next-mdx-remote/rsc'
-import { compile } from '@mdx-js/mdx'
-import { promises as fs, readdirSync, readFileSync } from 'fs';
+import { promises as fs, readdirSync } from 'fs';
 import path from 'path';
-import { parseFrontmatter, findMdxFilepath, getMdxDir, findSiblingMdxFilepath } from './helpers';
-
-import remarkFrontmatter from 'remark-frontmatter';
-import rehypeImgSize from 'rehype-img-size';
-import rehypeSlug from "rehype-slug";
-import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import rehypeExtractToc from "@stefanprobst/rehype-extract-toc";
-import rehypeExtractTocExport from "@stefanprobst/rehype-extract-toc/mdx";
-
+import { processMdx, getProcessedMdxFromParams, findMdxFilepath, getMdxDir, findSiblingMdxFilepath } from './helpers';
 import { markdownFolders } from '@/app/constants';
 import MDXPage from '.';
 import { notFound } from 'next/navigation';
 
-import { CopyToClipboard } from '@/components/Mdx/CopyToClipboard';
-
-const MDXComponents = { 
-    h1: (props) => <h1 className="scroll-mt-20" {...props} />,
-    h2: (props) => <section><h2 className="scroll-mt-20" {...props} /></section>,
-    h3: (props) => <section><h3 className="scroll-mt-20" {...props} /></section>,
-    pre: (props) => <CopyToClipboard><pre {...props}></pre></CopyToClipboard>,
-}
-
-// mdx to html options
-const mdxOptions = {
-    remarkPlugins: [
-        remarkFrontmatter,
-    ],
-    rehypePlugins: [
-        rehypeSlug,
-        [
-          rehypeAutolinkHeadings,
-          {
-            behavior: 'append',
-            properties: {
-              ariaHidden: false,
-              tabIndex: -1,
-              className: 'hash-link',
-            },
-          },
-        ],
-        [rehypeImgSize, { dir: 'public' }],
-    ],
-}
+import { MDXComponents } from '@/components/Mdx/MdxComponents';
 
 // Called when a page is accessed (only once on build with static site generation)
 // Finds mdx file to render based on slug then processes the page accordingly
 export default async function MdxPage({ params }) {
-    const {difficulty, slug} = params
-    const mdxDir = path.join(getMdxDir(), difficulty) 
+    const {slug} = params
+    const {default: Content, toc, error} = await getProcessedMdxFromParams(params)
+    if (error) return notFound()
 
-    const filepath = await findMdxFilepath(params)
-    if (!filepath) return notFound()
-    
-    // convert mdx to html
-    const rawmdx = await fs.readFile(path.join(mdxDir, filepath), 'utf-8')
-    const { content } = await compileMDX({
-        source: rawmdx,
-        components: MDXComponents,
-        options: { 
-            parseFrontmatter: true, 
-            mdxOptions: mdxOptions
-        },
-    })
-    
-    // get toc tree
-    const toc = await compile(rawmdx, {
-        remarkPlugins: [
-            remarkFrontmatter,
-        ],
-        rehypePlugins: [
-            rehypeSlug,
-            rehypeExtractToc,
-            rehypeExtractTocExport,
-        ]
-    })
-    
     const metadata = await getPages(params)
 
     return (
-        <MDXPage params={content} toc={toc.data.toc} metadata={metadata} slug={slug}/>
+        <MDXPage toc={toc} metadata={metadata} slug={slug}>
+            <Content components={MDXComponents}/>
+        </MDXPage>
     )
 }
 
@@ -91,13 +29,7 @@ export async function getPages(params) {
     const mdxFiles = await findSiblingMdxFilepath(params)
 
     return await Promise.all(mdxFiles.map(async (file) => {
-        const mdxFile = readFileSync(path.join(mdxDir, file), 'utf-8')
-        const { frontmatter , content } = await compileMDX({
-            source: mdxFile,
-            options: { 
-                parseFrontmatter: true,
-            },
-        })
+        const { frontmatter } = await processMdx(path.join(mdxDir, file))
 
         let slug = path.basename(file, path.extname(file))
         // nb: makes "index.mdx" reserved, can be improved if needed
@@ -106,26 +38,14 @@ export async function getPages(params) {
         return {
             metadata: frontmatter,
             slug,
-            content,
         }
     }))
 }
 
 // set the title for each page based on title set on frontmatter
 export async function generateMetadata({params}) {
-    const {difficulty, slug} = params
-    const mdxDir = path.join(getMdxDir(), difficulty) 
-
-    const filepath = await findMdxFilepath(params)
-    if (!filepath) return notFound()
-
-        const rawmdx = await fs.readFile(path.join(mdxDir, filepath), 'utf-8');
-    
-    const { frontmatter } = await compileMDX({source: rawmdx,
-        options: { 
-            parseFrontmatter: true, 
-        },
-    });
+    const {frontmatter, error} = await getProcessedMdxFromParams(params)
+    if (error) return notFound()
 
     return {title: frontmatter.title ? frontmatter.title + " | NAUR" : "NAUR" }
 }

--- a/naurffxiv/src/app/[difficulty]/[[...slug]]/page.js
+++ b/naurffxiv/src/app/[difficulty]/[[...slug]]/page.js
@@ -1,6 +1,6 @@
-import { promises as fs, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import path from 'path';
-import { processMdx, getProcessedMdxFromParams, findMdxFilepath, getMdxDir, findSiblingMdxFilepath } from './helpers';
+import { processMdx, getProcessedMdxFromParams, readAndParseJson, getMdxDir, findSiblingMdxFilepath } from './helpers';
 import { markdownFolders } from '@/app/constants';
 import MDXPage from '.';
 import { notFound } from 'next/navigation';
@@ -74,7 +74,7 @@ export async function generateStaticParams() {
             subtrees: await Promise.all(dir.subtreesToRead.map(async file => {
                 return {
                     subfolder: path.dirname(file),
-                    tree: JSON.parse(await fs.readFile(path.join(mdxDir, dir.folder, file), {encoding: 'utf-8'}))
+                    tree: await readAndParseJson(path.join(mdxDir, dir.folder, file))
                 }})),
             folder: dir.folder,
         }

--- a/naurffxiv/src/components/Mdx/MdxComponents.js
+++ b/naurffxiv/src/components/Mdx/MdxComponents.js
@@ -1,0 +1,8 @@
+import { CopyToClipboard } from '@/components/Mdx/CopyToClipboard';
+
+export const MDXComponents = { 
+    h1: (props) => <h1 className="scroll-mt-20" {...props} />,
+    h2: (props) => <section><h2 className="scroll-mt-20" {...props} /></section>,
+    h3: (props) => <section><h3 className="scroll-mt-20" {...props} /></section>,
+    pre: (props) => <CopyToClipboard><pre {...props}></pre></CopyToClipboard>,
+}

--- a/naurffxiv/src/markdown/ultimates/dsr.mdx
+++ b/naurffxiv/src/markdown/ultimates/dsr.mdx
@@ -3,9 +3,6 @@ title: Dragonsong's Reprise
 order: 2
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # Dragonsong's Reprise (Ultimate)
 ## Strats by Phase
 ### P1: Adelphel, Grinnaux and Charibert

--- a/naurffxiv/src/markdown/ultimates/fru.mdx
+++ b/naurffxiv/src/markdown/ultimates/fru.mdx
@@ -3,9 +3,6 @@ title: Futures Rewritten
 order: 0
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # Futures Rewritten (Ultimate)
 ## Strats by Phase
 ### P1: Fatebreaker

--- a/naurffxiv/src/markdown/ultimates/tea.mdx
+++ b/naurffxiv/src/markdown/ultimates/tea.mdx
@@ -3,9 +3,6 @@ title: The Epic of Alexander
 order: 3
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # The Epic of Alexander (Ultimate)
 ## Strats by Phase
 ### P1: Living Liquid

--- a/naurffxiv/src/markdown/ultimates/top.mdx
+++ b/naurffxiv/src/markdown/ultimates/top.mdx
@@ -3,9 +3,6 @@ title: The Omega Protocol
 order: 1
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # The Omega Protocol (Ultimate)
 ## Strats by Phase
 ### P1: Omega

--- a/naurffxiv/src/markdown/ultimates/ucob.mdx
+++ b/naurffxiv/src/markdown/ultimates/ucob.mdx
@@ -3,9 +3,6 @@ title: The Unending Coil of Bahamut
 order: 5
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # The Unending Coil of Bahamut (Ultimate)
 ## Strats by Phase
 ### P1: Twintania

--- a/naurffxiv/src/markdown/ultimates/uwu.mdx
+++ b/naurffxiv/src/markdown/ultimates/uwu.mdx
@@ -3,9 +3,6 @@ title: The Weapon's Refrain
 order: 4
 ---
 
-import MdxContent from '@/components/Mdx/MdxContent'
-export default MdxContent;
-
 # The Weapon's Refrain (Ultimate)
 ## Strats by Phase
 ### Phase 1: Garuda


### PR DESCRIPTION
Ticket: NA
Currently, the processing for each MDX page attempts to read the MDX files pages in 4 different places to:
1. Process the markdown into HTML
2. Generate a table of contents to be rendered separately
3. Process frontmatter for the page title
4. Process frontmatter for quick links section (all siblings)
Each time the MDX files were read and processed, they were done slightly differently every time, making the logic harder to follow. 
This PR simplifies all of this by processing all the necessary parts (content, frontmatter, table of contents) at the same time and caching the result. It also caches the processed `_meta.json` files too.