### PR TITLE
Make quick links' links entire area clickable

### DIFF
--- a/naurffxiv/src/components/Mdx/QuickLinks.js
+++ b/naurffxiv/src/components/Mdx/QuickLinks.js
@@ -9,14 +9,14 @@ export default function QuickLinks({metadata, slug}) {
                 {arr.map((ultimate) => {
                     return (
                     !slug || ultimate.slug == slug[slug.length-1] ? 
-                    <li key={ultimate.slug} className="transition-colors rounded-md bg-opacity-10 bg-slate-400 hover:bg-opacity-10 hover:bg-slate-300 py-2 px-4">
-                        <a href={ultimate.slug} className="block no-underline text-blue-400 hover:text-blue-500 transition-colors">
+                    <li key={ultimate.slug}>
+                        <a href={ultimate.slug} className="block no-underline text-blue-400 hover:text-blue-500 transition-colors rounded-md bg-opacity-10 bg-slate-400 hover:bg-opacity-10 hover:bg-slate-300 py-2 px-4">
                             {ultimate.metadata.title}
                         </a>
                     </li>
                         :
-                    <li key={ultimate.slug} className="transition-colors rounded-md hover:bg-opacity-10 hover:bg-slate-600 py-2 px-4">
-                        <a href={ultimate.slug} className="block no-underline text-slate-200 hover:text-white transition-colors">
+                    <li key={ultimate.slug}>
+                        <a href={ultimate.slug} className="block no-underline text-slate-200 hover:text-white transition-colors rounded-md hover:bg-opacity-10 hover:bg-slate-600 py-2 px-4">
                             {ultimate.metadata.title}
                         </a>
                     </li>


### PR DESCRIPTION
Ticket: NAUR-107
The clickable area of the links in the quick links section is smaller than the style is. This PR fixes that and makes the entire area clickable