### PR TITLE
Update navbar items' hover color to match rest

### DIFF
--- a/naurffxiv/src/components/Homepage/OfferingCards.js
+++ b/naurffxiv/src/components/Homepage/OfferingCards.js
@@ -23,7 +23,7 @@ const divs = [
         alt: "Bulb icon",
     },
     {
-        title: "Raiding Server Events",
+        title: "Raid Events",
         desc: `NAUR hosts a variety of events throughout the year for NA data centers,
                 designed to help players prog and clear high-end content.
                 Join us for fun parties that bring the community together to achieve your raiding goals.`,

--- a/naurffxiv/src/components/NavBar/NavBar.js
+++ b/naurffxiv/src/components/NavBar/NavBar.js
@@ -50,7 +50,9 @@ export default function NavBar() {
           <Box sx={{display: { xs: 'none', md: 'flex' } }}>
             <MenuList sx={{display: 'flex'}}>
               <li>
-                <MenuItem component="a" href="/">
+                <MenuItem component="a" href="/" style={{borderRadius: "4px"}} 
+                  sx={{':hover': {bgcolor: 'rgba(25, 118, 210, 0.04)'}}}
+                >
                   <Typography variant="h7" component="div" sx={{ textAlign: 'center' }}>
                       Home
                   </Typography>
@@ -59,7 +61,9 @@ export default function NavBar() {
                 <UltimateDropdown name="Ultimates" />
                 {pages.map((page) => (
                     <li key={page.name}>
-                      <MenuItem component="a" href={page.link}>
+                      <MenuItem component="a" href={page.link} style={{borderRadius: "4px"}} 
+                        sx={{':hover': {bgcolor: 'rgba(25, 118, 210, 0.04)'}}}
+                      >
                         <Typography sx={{ textAlign: 'center' }}>
                           {page.name}
                         </Typography>


### PR DESCRIPTION
NAUR-112
![image](https://github.com/user-attachments/assets/b5057d02-c0f4-4f07-8fb8-7225fbeafabe)
This makes the links match the "Ultimates" dropdown color

Also updates wording on homepage while we're at it by request