### PR TITLE
Wrap headers and content with sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,9 @@
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-mdx-frontmatter": "^5.0.0",
-        "remark-toc": "^9.0.0"
+        "remark-sectionize": "^2.1.0",
+        "remark-toc": "^9.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
@@ -7069,6 +7071,64 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-sectionize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remark-sectionize/-/remark-sectionize-2.1.0.tgz",
+      "integrity": "sha512-R/pHt1RLYrEqrbwOVXx8HnvvwOg+mxg8pE4kIWpIYE3/CuZhU8/PAx/0y1BbHWUA0jmTLTeWpUlDrS/B0pyd0g==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-find-after": "^4.0.1",
+        "unist-util-visit": "^4.1.2"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-toc": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-9.0.0.tgz",
@@ -8175,6 +8235,39 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-find-after/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx-frontmatter": "^5.0.0",
-    "remark-toc": "^9.0.0"
+    "remark-sectionize": "^2.1.0",
+    "remark-toc": "^9.0.0",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/src/app/[difficulty]/[[...slug]]/helpers.js
+++ b/src/app/[difficulty]/[[...slug]]/helpers.js
@@ -6,11 +6,13 @@ import { cache } from 'react';
 
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
+import remarkSectionize from 'remark-sectionize'
 import rehypeImgSize from 'rehype-img-size';
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeExtractToc from "@stefanprobst/rehype-extract-toc";
 import rehypeExtractTocExport from "@stefanprobst/rehype-extract-toc/mdx";
+import rehypeHeaderSections from '@/rehype/rehypeHeaderSections';
 
 // process each mdx file and cache it
 export const processMdx = cache(async (filepath) => {
@@ -22,7 +24,8 @@ export const processMdx = cache(async (filepath) => {
         baseUrl: import.meta.url,
         remarkPlugins: [
             remarkFrontmatter,
-            remarkMdxFrontmatter
+            remarkMdxFrontmatter,
+            remarkSectionize
         ],
         rehypePlugins: [
             rehypeSlug,
@@ -39,7 +42,8 @@ export const processMdx = cache(async (filepath) => {
             ],
             [rehypeImgSize, { dir: 'public' }],
             rehypeExtractToc,
-            [rehypeExtractTocExport, {name: "toc"}]
+            [rehypeExtractTocExport, {name: "toc"}],
+            rehypeHeaderSections,
         ]
     })
 

--- a/src/components/Mdx/MdxComponents.js
+++ b/src/components/Mdx/MdxComponents.js
@@ -6,8 +6,6 @@ import Streamable from "../Video/Streamable";
 
 export const MDXComponents = { 
     h1: (props) => <h1 className="scroll-mt-20" {...props} />,
-    h2: (props) => <section><h2 className="scroll-mt-20" {...props} /></section>,
-    h3: (props) => <section><h3 className="scroll-mt-20" {...props} /></section>,
     pre: (props) => <CopyToClipboard><pre {...props}></pre></CopyToClipboard>,
     YouTube,
     TwitchClip,

--- a/src/rehype/rehypeHeaderSections.js
+++ b/src/rehype/rehypeHeaderSections.js
@@ -1,0 +1,27 @@
+import {visit} from 'unist-util-visit'
+
+/*
+    this rehype plugin searches for <section> tags and then checks
+    whether its first child is a header tag from h2-h6
+    if it is, transfer the header's id to the section instead
+    this makes it so that fragments target the section
+    it also improves IntersectionObserver since it is now
+    tracking an entire section instead of a single header
+*/
+export default function rehypeHeaderSections() {
+    return function (tree) {
+        visit(tree, 'element', function (node) {
+            if (node.tagName !== 'section') return
+            if (!node.children) return
+
+            let allowedTags = ['h2', 'h3', 'h4', 'h5', 'h6']
+            let firstChild = node.children[0]
+
+            if (allowedTags.indexOf(firstChild.tagName) === -1) return
+            
+            node.properties.id = firstChild.properties.id
+            node.properties.class="scroll-mt-20"
+            firstChild.properties.id = null
+        })
+    }
+}

--- a/src/rehype/rehypeHeaderSections.js
+++ b/src/rehype/rehypeHeaderSections.js
@@ -1,12 +1,11 @@
 import {visit} from 'unist-util-visit'
 
 /*
-    this rehype plugin searches for <section> tags and then checks
-    whether its first child is a header tag from h2-h6
-    if it is, transfer the header's id to the section instead
-    this makes it so that fragments target the section
-    it also improves IntersectionObserver since it is now
-    tracking an entire section instead of a single header
+    This rehype plugin searches for <section> tags and then checks whether its first child 
+    is a header tag from h2-h6. If it is, transfer the header's id to the section instead.
+
+    This makes it so that fragments target the section. It also improves IntersectionObserver
+    since it is now tracking an entire section instead of a single header.
 */
 export default function rehypeHeaderSections() {
     return function (tree) {


### PR DESCRIPTION
Ticket: NAUR-121
The ScrollSpy component used to track where the user is currently at on the page currently only tracks header elements. On a section that's taller than the viewport, it will fail since the header element may fall out of view. To fix this, I wrapped every header and its content with a section tag and moved the id from the header to the section, so the underlying IntersectionObserver can keep track of what's on screen.