### PR TITLE
Add testing page

### DIFF
--- a/src/app/[difficulty]/[[...slug]]/page.js
+++ b/src/app/[difficulty]/[[...slug]]/page.js
@@ -103,14 +103,16 @@ export async function generateStaticParams() {
     }
     
     // form final slug format for return
-    return (meta.flatMap(folder => 
+    return [
+        process.env.NEXT_PROD !== "true" ? {difficulty: "testing", slug: ["page"]} : {},  // test page
+        ...(meta.flatMap(folder => 
         folder.subtrees.flatMap(subtree => 
             getSlugsFromTree(subtree.tree, subtree.subfolder, true).map(slug => ({
                 difficulty: folder.folder,
                 slug: subtree.subfolder === "." ? slug : subtree.subfolder.split("/").concat(slug)
             }))
         )
-    ))
+    ))]
 }
 
 export const dynamicParams = false

--- a/src/markdown/testing/_meta.json
+++ b/src/markdown/testing/_meta.json
@@ -1,0 +1,5 @@
+{
+    "page": {
+        "index": "page.mdx"
+    }
+}

--- a/src/markdown/testing/page.mdx
+++ b/src/markdown/testing/page.mdx
@@ -1,0 +1,136 @@
+---
+title: Dragonsong's Reprise
+order: 0
+collapseToc: true
+---
+{/*
+the frontmatter above needs to be present in every mdx file for now,
+order must begin at 0 based on how many mdx files there are in the slug
+*/}
+# Testing page
+If you see this on naurffxiv that means I messed up!
+
+## example usage of video components
+No need to import, classes are imported within @/components/Mdx/MdxComponents.js  
+
+https://www.youtube.com/watch?v=6yUKtPIRa5M
+<YouTube videoId="6yUKtPIRa5M"/>   
+
+https://www.twitch.tv/videos/2149278406
+<TwitchVoD videoId="2149278406"/>
+
+https://www.twitch.tv/jerma985/clip/KnottyOddFishShazBotstix
+<TwitchClip videoId="KnottyOddFishShazBotstix"/>
+
+https://streamable.com/2h30
+<Streamable videoId="2h30"/>
+
+## Quae tamen Elide agant
+
+Lorem markdownum quaque mater sed quicquam adest: flammas agitur, ruit regi
+Charybdis *et* flebat **versantes fumantia dolores** Dianae. *Et latices*! Et
+cum unxit! Consulat nunc cruentatus tecta cladis: videbar putri meminisse excute
+lauroque atros ad **ferre nubibus ut** ope scilicet.
+
+Et Circes pigre nec curat cervice: [felix fossa dolorque](http://noster.net/)?
+Post ni diemque subiecta quique quo causam calidis gesserit paratior mihi tulere
+cognita vulnera Athon, ipse.
+
+Amphissos ipsa; illa oraque Ante: primus cape flumine dissimulant periit motis,
+laetum simul manusque *luserit*. Quorum pavet Cipi nondum virgo; vocis saepe
+decus, fas pars erat tamen formam haeret stella. Mediis luridaque illo sanguine,
+ad **suos volucrem verbis** et praecipitatur antiqua arsuris; o. Ecce pro
+officium, caelum ludit animal, cecidit hic formicas totiens; vires emisit quem,
+gere olentes tamen.
+
+### Quae tamen Elide agant a
+
+Lorem markdownum quaque mater sed quicquam adest: flammas agitur, ruit regi
+Charybdis *et* flebat **versantes fumantia dolores** Dianae. *Et latices*! Et
+cum unxit! Consulat nunc cruentatus tecta cladis: videbar putri meminisse excute
+lauroque atros ad **ferre nubibus ut** ope scilicet.
+
+Et Circes pigre nec curat cervice: [felix fossa dolorque](http://noster.net/)?
+Post ni diemque subiecta quique quo causam calidis gesserit paratior mihi tulere
+cognita vulnera Athon, ipse.
+
+Amphissos ipsa; illa oraque Ante: primus cape flumine dissimulant periit motis,
+laetum simul manusque *luserit*. Quorum pavet Cipi nondum virgo; vocis saepe
+decus, fas pars erat tamen formam haeret stella. Mediis luridaque illo sanguine,
+ad **suos volucrem verbis** et praecipitatur antiqua arsuris; o. Ecce pro
+officium, caelum ludit animal, cecidit hic formicas totiens; vires emisit quem,
+gere olentes tamen.
+
+### Quae tamen Elide agant b
+
+Lorem markdownum quaque mater sed quicquam adest: flammas agitur, ruit regi
+Charybdis *et* flebat **versantes fumantia dolores** Dianae. *Et latices*! Et
+cum unxit! Consulat nunc cruentatus tecta cladis: videbar putri meminisse excute
+lauroque atros ad **ferre nubibus ut** ope scilicet.
+
+Et Circes pigre nec curat cervice: [felix fossa dolorque](http://noster.net/)?
+Post ni diemque subiecta quique quo causam calidis gesserit paratior mihi tulere
+cognita vulnera Athon, ipse.
+
+
+Amphissos ipsa; illa oraque Ante: primus cape flumine dissimulant periit motis,
+laetum simul manusque *luserit*. Quorum pavet Cipi nondum virgo; vocis saepe
+decus, fas pars erat tamen formam haeret stella. Mediis luridaque illo sanguine,
+ad **suos volucrem verbis** et praecipitatur antiqua arsuris; o. Ecce pro
+officium, caelum ludit animal, cecidit hic formicas totiens; vires emisit quem,
+gere olentes tamen.
+
+### Quae tamen Elide agant c
+
+Lorem markdownum quaque mater sed quicquam adest: flammas agitur, ruit regi
+Charybdis *et* flebat **versantes fumantia dolores** Dianae. *Et latices*! Et
+cum unxit! Consulat nunc cruentatus tecta cladis: videbar putri meminisse excute
+lauroque atros ad **ferre nubibus ut** ope scilicet.
+
+Et Circes pigre nec curat cervice: [felix fossa dolorque](http://noster.net/)?
+Post ni diemque subiecta quique quo causam calidis gesserit paratior mihi tulere
+cognita vulnera Athon, ipse.
+
+Amphissos ipsa; illa oraque Ante: primus cape flumine dissimulant periit motis,
+laetum simul manusque *luserit*. Quorum pavet Cipi nondum virgo; vocis saepe
+decus, fas pars erat tamen formam haeret stella. Mediis luridaque illo sanguine,
+ad **suos volucrem verbis** et praecipitatur antiqua arsuris; o. Ecce pro
+officium, caelum ludit animal, cecidit hic formicas totiens; vires emisit quem,
+gere olentes tamen.
+
+## Messenia in lente
+
+Amphissos ipsa; illa oraque Ante: primus cape flumine dissimulant periit motis,
+laetum simul manusque *luserit*. Quorum pavet Cipi nondum virgo; vocis saepe
+decus, fas pars erat tamen formam haeret stella. Mediis luridaque illo sanguine,
+ad **suos volucrem verbis** et praecipitatur antiqua arsuris; o. Ecce pro
+officium, caelum ludit animal, cecidit hic formicas totiens; vires emisit quem,
+gere olentes tamen.
+
+1. Est domus taedia secum venas putet
+2. Nudos agnus
+3. Tempore linguae est Liber nemorum prior est
+
+## Iusque caelo flebile
+
+Pachyne crista nervo. Non non delere ipsa thalamos Iovi in, mihi perdite et
+ametur thalami. [Timuit](http://sublimis-sed.io/pomisfluidove.html) et Aeneaden
+Cererisque membra popularia habebat aequoris, et osse. Felicia picta quamvis
+cuius [dant maestissimus norat](http://illud-latus.com/ingenium-fuerant.aspx)
+diruerent cepi mora formidabilis armis, *saepe sidera*. *Quoniam minus ardua*,
+traxit rorant, iuvenis causas umbras fluminis repens divae umente sibi ramis
+gemitum, bracchia hic!
+
+## Tetigisse stirpe pinnas sortem paventes tardis timuitque
+
+Natus notae tactas, diu loricaeque facie, data cum. Licet *tritis*, quae iam
+Veneris fulvis, sex **quondam** haberet. Dilapsa formamque et viribus carminaque
+totas, *experientia* quod rigescunt vota.
+
+> Magos meus utraque Circes. Hic et feros inmitibus totumque, est Cinyreia nec
+> accipiunt, veniebat. Ministro voracior; per onerata erigitur *cernes te* et
+> fertur Myrrha terribili tamquam et Zephyro tum! Quae que ita barbam dextra.
+
+Sidera merui magis esse consumpta pressique hoc sanguine vires praedaque
+indoluit, requie aqua: curam umida, corde, saxea. Quereretur menso. Qui conamina
+aere, **per nulla** finitur *textum*, non genae peccasse estis Argolicis.


### PR DESCRIPTION
Ticket: NAUR-142
This adds a testing page that is only enabled when the `NEXT_PROD` environment variable isn’t set to true. I have already configured the environment variable on the main site, so the testing page should only ever be available locally and on the staging domain.

Testing page is available at `/testing/page`, more can be added if needed