### PR TITLE
Make external links open a new tab in MDX pages

### DIFF
--- a/src/components/Mdx/MdxComponents.js
+++ b/src/components/Mdx/MdxComponents.js
@@ -6,6 +6,10 @@ import TwitchVoD from "../Video/TwitchVoD";
 import Streamable from "../Video/Streamable";
 
 export const MDXComponents = { 
+    a: (props) => {
+        if (props.href.startsWith("http")) return <a target="_blank" {...props}/>
+        return <a {...props}/>
+    },
     h1: (props) => <h1 className="scroll-mt-20" {...props} />,
     img: (props) => <ImageModal {...props}/>,
     pre: (props) => <CopyToClipboard><pre {...props}></pre></CopyToClipboard>,

--- a/src/markdown/testing/page.mdx
+++ b/src/markdown/testing/page.mdx
@@ -10,6 +10,10 @@ order must begin at 0 based on how many mdx files there are in the slug
 # Testing page
 If you see this on naurffxiv that means I messed up!
 
+## external/internal links
+[internal link](/testing/page)  
+[external link](https://github.com/naurffxiv/naurffxiv)
+
 ## example usage of video components
 No need to import, classes are imported within @/components/Mdx/MdxComponents.js  
 


### PR DESCRIPTION
Ticket: NAUR-147
This PR makes external links in MDX pages open in a new tab, while keeping internal links on the same tab.
Testing is available at /testing/page