### PR TITLE
Use alternative toml package and add json option to Buffs component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "remark-toc": "^9.0.0",
         "sass": "^1.86.0",
         "sharp": "^0.33.5",
-        "toml": "^3.0.0",
+        "smol-toml": "^1.3.1",
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
@@ -8287,6 +8287,18 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
+      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "remark-toc": "^9.0.0",
     "sass": "^1.86.0",
     "sharp": "^0.33.5",
-    "toml": "^3.0.0",
+    "smol-toml": "^1.3.1",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/src/components/Mdx/Buff.js
+++ b/src/components/Mdx/Buff.js
@@ -54,11 +54,23 @@ function tooltip({name, description, dur, explanation, short, stacks}) {
     description: optional string. Override the buff description text in the tooltip (never used, I think).
     explanation: optional string. Override the buff explanation text in the tooltip (never used, I think).
 */
-export default async function Buff({b, datapath, description, dur, explanation,  mdxDir, short, stacks}) {
-    datapath = datapath || "buffs.toml"
+export default async function Buff({b, datapath, description, dur, explanation, mdxDir, short, stacks, type = "toml"}) {
+    let filename = ""
+    let buffsData = {}
+    switch (type) {
+        case "json":
+            datapath = datapath || `buffs.json`
+            filename = String(fs.readFileSync(path.join(mdxDir, datapath)))
+            buffsData = JSON.parse(filename)
+            break
+        default:
+            datapath = datapath || "buffs.toml"
+            filename = String(fs.readFileSync(path.join(mdxDir, datapath)))
+            buffsData = parse(filename)
+            break
+    }
 
-    let toml = parse(String(fs.readFileSync(path.join(mdxDir, datapath))))
-    let buff = toml[b]
+    let buff = buffsData[b]
 
     let icon = String(buff.icon)
     let fill = 6 - icon.length

--- a/src/components/Mdx/Buff.js
+++ b/src/components/Mdx/Buff.js
@@ -1,4 +1,4 @@
-import { parse } from 'toml'
+import { parse } from 'smol-toml'
 import path from 'path';
 import fs from 'fs'
 import { Tooltip } from '@mui/material';

--- a/src/markdown/testing/buffs.json
+++ b/src/markdown/testing/buffs.json
@@ -1,0 +1,16 @@
+{
+    "neurolink": {
+        "name": "Neurolink",
+        "icon": 215545,
+        "description": "Movement is slowed, damage dealt and HP recovery via actions is reduced.",
+        "explanation": "0 damage but hatch no boom.",
+        "phases": [1, 3, 4]
+    },
+    "phoenix-blessing": {
+        "name": "Phoenix's Blessing",
+        "icon": 215819,
+        "description": "Damage dealt is increased.",
+        "explanation": "big damage hours",
+        "phases": [5]
+    }
+}

--- a/src/markdown/testing/page.mdx
+++ b/src/markdown/testing/page.mdx
@@ -31,7 +31,8 @@ https://streamable.com/2h30
 
 ### Buff components
 Lorem markdownum quaque mater sed quicquam adest <Buff b="neurolink"/> flammas agitur, ruit regi
-Charybdis *et* flebat **versantes fumantia <Buff b="phoenix-blessing"/> dolores** Dianae.
+Charybdis *et* flebat **versantes fumantia <Buff b="phoenix-blessing"/> dolores** Dianae.  
+json test: <Buff b="phoenix-blessing" type="json" />
 
 ## Quae tamen Elide agant
 


### PR DESCRIPTION
Ticket: NAUR-149
Since the phases in buffs.toml could be a decimal (intermissions), it could be an array with integers and floats. Although the newer TOML specification allows for mixed type arrays, the older specification does not. The TOML package we are using right now is outdated, so I've found an alternative package to use instead that follows the most recent specification.
I've additionally added an option to use JSON files instead