### PR TITLE
Various bug fixes for ToC and ImageModal

### DIFF
--- a/src/app/[difficulty]/[[...slug]]/index.js
+++ b/src/app/[difficulty]/[[...slug]]/index.js
@@ -9,12 +9,12 @@ import "./buffs.scss"
 const MDXPage = ({children, toc, siblingData, slug, frontmatter}) => {
     return (
         <MdxLayout>
-            <div className="grid grid-cols-1 lg:grid-cols-[90ch_1fr] xl:grid-cols-[1fr_90ch_1fr] max-w-screen-2xl mx-auto py-6">
-                <div className="prose prose-invert top-[5.5rem] self-start hidden xl:block sticky h-screen scrollbar">
+            <div className="grid grid-cols-1 lg:grid-cols-[90ch_1fr] xl:grid-cols-[1fr_90ch_1fr] max-w-screen-2xl mx-auto">
+                <div className="top-[5.5rem] self-start hidden xl:block sticky h-[calc(100vh-100px)] scrollbar">
                     <TableOfContents toc={toc} frontmatter={frontmatter}/>
                 </div>
 
-                <article className="max-w-[90ch] prose prose-invert m-auto mx-6">
+                <article className="max-w-[90ch] prose prose-invert m-auto mx-6 py-6">
                     {children}
                 </article>
 

--- a/src/app/[difficulty]/[[...slug]]/mdx.css
+++ b/src/app/[difficulty]/[[...slug]]/mdx.css
@@ -1,15 +1,24 @@
 /* table of contents */
+
 .toc li {
-    margin-top: 1rem;
-  }
-  
-.toc a {
-  padding: 0.75rem;
+  margin: 0;
+}
+
+.toc ul {
+  margin-top: 0;
 }
 
 .toc a:hover {
-  border-radius: 0.375rem;
   color: white;
+}
+
+.toc-url-container {
+  border-radius: 0.375rem;
+  transition: background-color 0.1s ease;
+  padding: 0.75rem;
+}
+
+.toc-url-container:hover {
   background-color: rgba(71, 85, 105, 0.1);
 }
 
@@ -17,7 +26,6 @@
   transition: color 0.1s ease;
   transition: background-color 0.1s ease;
   color: rgb(226 232 240);
-  padding: 0.5rem;
   text-decoration: none;
 }
 
@@ -39,7 +47,7 @@ nav.toc-collapse > div > ul > li div {
 }
 
 /* highlight parents of active section */
-nav.toc-collapse li:has(.toc-current) > a:not(.toc-current) {
+nav.toc-collapse li:has(.toc-current) > div > a:not(.toc-current) {
   color: rgb(161, 199, 255);
 }
 
@@ -51,19 +59,19 @@ nav.toc-collapse li div:has(.toc-current) > ul {
 }
 
 /* show children of currently active section */
-nav.toc-collapse li:has(> a.toc-current) > div > ul {
+nav.toc-collapse li:has(div > a.toc-current) > div > ul {
   margin-bottom: 0 !important;
 }
 
-/* hide inactive sections */
-nav.toc-collapse div > ul:not(.toc-current) {
-  margin-bottom: -100%;
-  transition: all 0.2s ease-in-out;
+/* hide inactive sections (skips first div) */
+nav.toc-collapse div div > ul:not(.toc-current) {
+  margin-bottom: -150%;
+  transition: all 0.3s ease-in-out;
 }
 
 /* collapsible toc dropdown arrow */
 /* parent of active section */
-nav.toc-collapse li:has(.toc-current) > a:not(.toc-current) svg {
+nav.toc-collapse li:has(.toc-current) > div > a:not(.toc-current) svg {
   transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   transform: rotate(0) !important;
 }

--- a/src/components/Mdx/ImageModal.js
+++ b/src/components/Mdx/ImageModal.js
@@ -11,10 +11,10 @@ export default function ImageModal({src, compressedExt = "avif", ...props}) {
     let compressed = src.substr(0, src.lastIndexOf(".")) + `.${compressedExt}`
     return (
         <>
-            <button onClick={handleOpen}>
+            <button onClick={handleOpen} className="not-prose">
                 <Image src={compressed} {...props}/>
             </button>
-            <Modal open={open} onClose={handleClose} aria-labelledby={props.alt}>
+            <Modal open={open} onClose={handleClose} aria-labelledby={props.alt} className="not-prose">
                 <div className="image-modal">
                     <Image src={src} {...props}/>
                 </div>

--- a/src/components/Mdx/TableOfContents.js
+++ b/src/components/Mdx/TableOfContents.js
@@ -6,10 +6,14 @@ function recursiveToc(toc, collapse, level = 0) {
     // ignore first level headers, head straight to h2
     const currLevel = level ? toc.map((li) => (
           <li key={li.id}>
-            <a href={`#${li.id}`} className="toc-links">
-                {li.value}
-                {collapse && li.children ? <span className="ml-1"><ArrowDropDownIcon className="-rotate-90 transition-all"/></span> : <></>}
-            </a>
+            <div className="w-fit">
+                <a href={`#${li.id}`} className="toc-links">
+                    <div className="toc-url-container">
+                        {li.value}
+                        {collapse && li.children ? <span className="ml-1"><ArrowDropDownIcon className="transition-all -rotate-90"/></span> : <></>}
+                    </div>
+                </a>
+            </div>
             <div>{li.children ? recursiveToc(li.children, collapse, level + 1) : <></>}</div>
           </li>
     )) : toc.map((li) => (
@@ -19,7 +23,7 @@ function recursiveToc(toc, collapse, level = 0) {
     ))
 
     return ( level ? 
-        <ul className="list-none ps-1 toc">
+        <ul className="list-none ps-4 toc">
             {currLevel}
         </ul> : <>{currLevel}</>
     )


### PR DESCRIPTION
Ticket: NAUR-150
This PR fixes various bugs with the table of contents and ImageModal.

ToC:
- Properly indent when header is wrapped
- Entire background of a link is now clickable instead of just the text
- Fix a margin bug that sometimes occurs
- Adjust height so that overflow scrolls properly at certain resolutions

ImageModal:
- Remove margin from button