### PR TITLE
fix: update repository links to use the future domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # dependencies
 /node_modules
-/naurffxiv/node_modules
-/naurffxiv/.next
 /.pnp
 .pnp.js
 .yarn/install-state.gz

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ npx eslint . --ext .js,.jsx,.ts,.tsx
 
 # Contributing
 
-If you would to contribute, please take a look over at our [Wiki](https://github.com/naurffxiv/naurffxiv/wiki) on certain processes.
+If you would to contribute, please take a look over at our [Wiki](https://github.com/naurffxiv/naurffxiv.com/wiki) on certain processes.

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -107,7 +107,7 @@ export const otherList = [
   },
   {
     title: "GitHub Repository",
-    url: "https://github.com/naurffxiv/naurffxiv",
+    url: "https://github.com/naurffxiv/naurffxiv.com",
   },
   {
     title: "Findingway.io",

--- a/src/components/Mdx/Buff.js
+++ b/src/components/Mdx/Buff.js
@@ -49,7 +49,7 @@ function tooltip({ name, description, dur, explanation, short, stacks }) {
 }
 
 /*
-    https://github.com/naurffxiv/naurffxiv/issues/103
+    https://github.com/naurffxiv/naurffxiv.com/issues/103
     b: string. The key into a (fight-specific) TOML file with buff data in it. This is where the name, icon, game text, and explanation come from, as well as whether the buff has the cleansable bar or not. More on the data file in another issue.
     dur: string. The buff duration text to render under the buff icon. (Allowing an integer instead of a string is a helpful shorthand, but not necessary.)
     short: boolean (default false). If true, the name is not displayed.

--- a/src/markdown/testing/page.mdx
+++ b/src/markdown/testing/page.mdx
@@ -13,7 +13,7 @@ If you see this on naurffxiv that means I messed up!
 ## external/internal links
 
 [internal link](/testing/page)  
-[external link](https://github.com/naurffxiv/naurffxiv)
+[external link](https://github.com/naurffxiv/naurffxiv.com)
 
 ## example usage of video components
 

--- a/src/markdown/ultimate/guide/dsr_index.mdx
+++ b/src/markdown/ultimate/guide/dsr_index.mdx
@@ -17,7 +17,7 @@ These strats are commonly referred to as APD or NAUR strats.
 If you have any questions regarding this guide, please feel free to join our
 [Discord](https://discord.com/invite/naurffxiv) and ask them.
 Any issues or concerns can also be reported on the
-[GitHub repository](https://github.com/naurffxiv/naurffxiv).
+[GitHub repository](https://github.com/naurffxiv/naurffxiv.com).
 
 ## Pre-Fight Notes
 


### PR DESCRIPTION
We should not merge this until we are ready to update the repository. Just opening the PR for when its ready.