### PR TITLE
fix: apostrophe display in Hero section + nit colon

### DIFF
--- a/src/components/Homepage/Hero.js
+++ b/src/components/Homepage/Hero.js
@@ -5,12 +5,12 @@ export default function Header() {
   function Text() {
     return (
       <div className="grid max-w-prose gap-y-3 md:gap-y-6">
-        <h1 className="text-4xl xl:text-6xl font-bold">NAUR</h1>
+        <h1 className="text-4xl font-bold xl:text-6xl">NAUR</h1>
         <h3 className="text-lg/7 xl:text-2xl/9">
           NAUR (NA Ultimate Raiding) is a community of high-end raiders on North
-          American Data Centers for Final Fantasy XIV: Online. Come connect with
+          American Data Centers for Final Fantasy XIV Online. Come connect with
           other high-end raiders, find statics, and share the enjoyment of
-          FFXIV`&apos`s toughest content.
+          FFXIV&apos;s toughest content.
         </h3>
         <a
           href="https://discord.com/invite/naurffxiv"
@@ -27,8 +27,8 @@ export default function Header() {
   }
 
   return (
-    <div className="max-w-screen-2xl grid md:grid-cols-2 mx-auto 2xl:px-6">
-      <div className="bg-center bg-header-default px-5 md:bg-none md:bg-left py-16">
+    <div className="grid mx-auto max-w-screen-2xl md:grid-cols-2 2xl:px-6">
+      <div className="px-5 py-16 bg-center bg-header-default md:bg-none md:bg-left">
         <div className="max-w-3xl mx-auto mr-0">
           <div className="max-w-fit">
             <Text />
@@ -36,7 +36,7 @@ export default function Header() {
         </div>
       </div>
       <div className="max-w-screen-md">
-        <div className="hidden md:block bg-header-wide bg-cover bg-center h-full">
+        <div className="hidden h-full bg-center bg-cover md:block bg-header-wide">
           <div className="h-full bg-header-right-gradient 2xl:bg-header-right-ultrawide-gradient" />
         </div>
       </div>


### PR DESCRIPTION
Fixed the incorrect apostrophe rendering in the main page description

Also corrected the title reference by removing the colon after Final Fantasy XIV, since the base game's name does not include a colon, only expansions like *Final Fantasy XIV: Dawntrail* use it.