### PR TITLE
fix: Add Top Padding to Resource Pages

### DIFF
--- a/src/app/[difficulty]/[[...slug]]/index.js
+++ b/src/app/[difficulty]/[[...slug]]/index.js
@@ -13,7 +13,7 @@ const MDXPage = ({ children, toc, siblingData, slug, frontmatter }) => {
         <div className="top-[5.5rem] self-start hidden xl:block sticky h-[calc(100vh-100px)] scrollbar">
           <TableOfContents toc={toc} frontmatter={frontmatter} />
         </div>
-        <article className="max-w-[90ch] min-h-screen prose prose-invert m-auto mx-6">
+        <article className="max-w-[90ch] min-h-screen prose prose-invert m-auto mx-6 pt-8">
           {children}
         </article>
         <div className="prose prose-invert top-[5.5rem] self-start hidden lg:block sticky">


### PR DESCRIPTION
This PR adds proper spacing between the top of resource pages and their content. Previously, headings and content were flush with the top of the page, which affected readability and visual hierarchy.

- Added `pt-8` (32px) padding to the top of article elements in resource pages
- This change affects all content pages under the `[difficulty]/[[...slug]]` routes

Before: 
![image](https://github.com/user-attachments/assets/9a7f2f7b-d88f-495e-b5dc-6cd1de722971)

After:
![image](https://github.com/user-attachments/assets/bcdf1f98-a0db-4383-9085-080b9a89a359)

---

Mobile:

Before:
![image](https://github.com/user-attachments/assets/ac5707ef-18f6-4621-b617-f7a99ec5db8c)
After:
![image](https://github.com/user-attachments/assets/cfd37bc1-7272-432b-85e8-a0f8a5f2387c)

Fixes #187 