### PR TITLE
Mobile Quick Links and style update

### DIFF
--- a/src/app/[difficulty]/[[...slug]]/index.js
+++ b/src/app/[difficulty]/[[...slug]]/index.js
@@ -1,27 +1,30 @@
 "use client";
 import MdxLayout from "@/components/Mdx/MdxLayout";
-import React from "react";
 import TableOfContents from "@/components/Mdx/TableOfContents";
 import QuickLinks from "@/components/Mdx/QuickLinks";
+import MobileDrawer from "@/components/Mdx/Layout/MobileDrawer";
 import "./mdx.css";
 import "./buffs.scss";
 
-const MDXPage = ({ children, toc, siblingData, slug, frontmatter }) => {
+function MDXPage({ children, toc, siblingData, slug, frontmatter }) {
+  const quickLinks = <QuickLinks siblingData={siblingData} slug={slug} />;
+
   return (
     <MdxLayout>
       <div className="grid grid-cols-1 lg:grid-cols-[90ch_1fr] xl:grid-cols-[1fr_90ch_1fr] max-w-screen-2xl mx-auto">
-        <div className="top-[5.5rem] self-start hidden xl:block sticky h-[calc(100vh-100px)] scrollbar">
+        <aside className="top-[5.5rem] self-start hidden xl:block sticky h-[calc(100vh-100px)] scrollbar">
           <TableOfContents toc={toc} frontmatter={frontmatter} />
-        </div>
-        <article className="max-w-[90ch] min-h-screen prose prose-invert m-auto mx-6 pt-8">
+        </aside>
+        <main className="max-w-[90ch] min-h-screen prose prose-invert m-auto mx-6 pt-8">
           {children}
-        </article>
-        <div className="prose prose-invert top-[5.5rem] self-start hidden lg:block sticky">
-          <QuickLinks siblingData={siblingData} slug={slug} />
-        </div>
+        </main>
+        <aside className="prose prose-invert top-[5.5rem] self-start hidden lg:block sticky">
+          {quickLinks}
+        </aside>
+        <MobileDrawer>{quickLinks}</MobileDrawer>
       </div>
     </MdxLayout>
   );
-};
+}
 
 export default MDXPage;

--- a/src/components/Mdx/Layout/MobileDrawer.js
+++ b/src/components/Mdx/Layout/MobileDrawer.js
@@ -1,0 +1,36 @@
+import { Drawer, IconButton } from "@mui/material";
+import { MenuOpen } from "@mui/icons-material";
+import React from "react";
+
+function MobileDrawer({ children }) {
+  const [mobileOpen, setOpen] = React.useState(false);
+  const toggleDrawer = (newOpen) => () => {
+    setOpen(newOpen);
+  };
+
+  return (
+    <div className="sticky bottom-0 z-10 flex items-center justify-end max-w-full mr-2 max-h-0 lg:hidden">
+      <Drawer
+        open={mobileOpen}
+        onClose={toggleDrawer(false)}
+        anchor="right"
+        slotProps={{ paper: { sx: { backgroundColor: "#1A3549" } } }}
+      >
+        {children}
+      </Drawer>
+      <IconButton
+        sx={{
+          background: "#28506E",
+          ":hover": { background: "#1A3549" },
+          marginBottom: "4rem",
+        }}
+        onClick={() => setOpen(true)}
+        size="large"
+      >
+        <MenuOpen sx={{ color: "white" }} />
+      </IconButton>
+    </div>
+  );
+}
+
+export default MobileDrawer;

--- a/src/components/Mdx/QuickLinks.js
+++ b/src/components/Mdx/QuickLinks.js
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 // builds the tree
 function buildTree(siblingData) {
   const root = {};
@@ -26,13 +27,16 @@ function buildTree(siblingData) {
 
 // returns a single quick link component
 // highlighted if the page matches the slug
-function quickLinkEntry(entry, currentSlug) {
+function quickLinkEntry(entry, currentSlug, isFirst) {
   if (entry.slug === currentSlug) {
     return (
       <li key={entry.slug} className="ps-0">
         <a
           href={entry.slug}
-          className="block px-4 py-2 text-blue-400 no-underline transition-colors border-r-2 border-blue-400 hover:text-blue-500 rounded-l-md bg-opacity-10 bg-slate-400 hover:bg-opacity-10 hover:bg-slate-300"
+          className={clsx({
+            "block px-4 py-2 text-blue-400 no-underline transition-colors border-r-2 border-blue-400 hover:text-blue-500 rounded-l-md bg-opacity-10 bg-slate-400 hover:bg-opacity-10 hover:bg-slate-300": true,
+            "ml-4": isFirst,
+          })}
         >
           {entry.title}
         </a>
@@ -43,7 +47,10 @@ function quickLinkEntry(entry, currentSlug) {
       <li key={entry.slug} className="ps-0">
         <a
           href={entry.slug}
-          className="block px-4 py-2 no-underline transition-colors border-r-2 border-transparent text-slate-200 hover:border-r-2 hover:border-slate-200 hover:text-white rounded-l-md hover:bg-opacity-10 hover:bg-slate-600"
+          className={clsx({
+            "block px-4 py-2 no-underline transition-colors border-r-2 border-transparent text-slate-200 hover:border-r-2 hover:border-slate-200 hover:text-white rounded-l-md hover:bg-opacity-10 hover:bg-slate-600": true,
+            "ml-4": isFirst,
+          })}
         >
           {entry.title}
         </a>
@@ -65,6 +72,7 @@ function recursiveLinks(tree, currentSlug, isFirst = true) {
         would skip only archive
     */
   const groups = Object.keys(tree);
+  if (groups.length === 0) return;
   if (isFirst && groups.length == 1 && groups[0] !== "pages") {
     const key = groups[0];
     return <>{recursiveLinks(tree[key], currentSlug)}</>;
@@ -75,7 +83,9 @@ function recursiveLinks(tree, currentSlug, isFirst = true) {
   // populate section with pages first
   if (tree["pages"]) {
     children.push(
-      ...tree["pages"].map((entry) => quickLinkEntry(entry, currentSlug)),
+      ...tree["pages"].map((entry) =>
+        quickLinkEntry(entry, currentSlug, isFirst),
+      ),
     );
   }
 
@@ -84,13 +94,15 @@ function recursiveLinks(tree, currentSlug, isFirst = true) {
   for (const group of groups) {
     if (group === "pages") continue;
     const title = group[2] === "-" ? group.substring(3) : group;
+    const child = recursiveLinks(tree[group], currentSlug, false);
+
     children.push(
       <li
         key={group}
         className={`${sameGroup > 0 ? "mt-4" : "mt-2"} ml-4 p-0 list-none list-inside`}
       >
         <h2 className="mt-4 mb-2 ml-4">{title}</h2>
-        {recursiveLinks(tree[group], currentSlug, false)}
+        {child}
       </li>,
     );
     sameGroup += 1;
@@ -161,7 +173,7 @@ export default function QuickLinks({ siblingData, slug }) {
   siblingData.sort(quickLinksSort);
   const siblingDataTree = buildTree(siblingData);
   return (
-    <div className="list-none quick-links-div min-w-[30ch] w-fit prose prose-invert">
+    <div className="list-none quick-links-div min-w-[30ch] w-[22rem] prose prose-invert">
       {recursiveLinks(siblingDataTree, slug)}
     </div>
   );


### PR DESCRIPTION
Implements #165, fixes #195 
This PR implements a drawer to access quick links on mobile devices:
![image](https://github.com/user-attachments/assets/12893a3a-cec5-4f6a-9295-a958d4b73f32)
![image](https://github.com/user-attachments/assets/bf177e7e-553b-4439-8fa9-126d8b213610)

It also adjusts the padding of the desktop quick links to have the first level entry be the same as the second level.