### PR TITLE
Image modal adjustments

### DIFF
--- a/src/app/[difficulty]/[[...slug]]/mdx.css
+++ b/src/app/[difficulty]/[[...slug]]/mdx.css
@@ -98,14 +98,6 @@ h6:hover span.icon-link::before {
   opacity: 1;
 }
 
-.image-modal {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: 24;
-  padding: 4;
-}
 .scrollbar {
   scrollbar-color: #b9bfc7 #0000;
   overflow-y: auto;

--- a/src/components/Mdx/ImageModal.js
+++ b/src/components/Mdx/ImageModal.js
@@ -20,7 +20,7 @@ export default function ImageModal({ src, compressedExt = "avif", ...props }) {
         aria-labelledby={props.alt}
         className="not-prose"
       >
-        <div className="image-modal">
+        <div className="absolute top-1/2 left-[8%] -translate-x-[4%] xl:left-1/2 xl:-translate-x-1/2 -translate-y-1/2 shadow-[24] p-1">
           <Image src={src} {...props} />
         </div>
       </Modal>

--- a/src/components/Mdx/ImageModal.js
+++ b/src/components/Mdx/ImageModal.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Modal from "@mui/material/Modal";
 import Image from "next/image";
 
+// we can disable warnings for no alt-text as it will be provided by props
 export default function ImageModal({ src, compressedExt = "avif", ...props }) {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
@@ -12,6 +13,7 @@ export default function ImageModal({ src, compressedExt = "avif", ...props }) {
   return (
     <>
       <button onClick={handleOpen} className="not-prose">
+        {/* eslint-disable-next-line jsx-a11y/alt-text */}
         <Image src={compressed} {...props} />
       </button>
       <Modal
@@ -21,6 +23,7 @@ export default function ImageModal({ src, compressedExt = "avif", ...props }) {
         className="not-prose"
       >
         <div className="absolute top-1/2 left-[8%] -translate-x-[4%] xl:left-1/2 xl:-translate-x-1/2 -translate-y-1/2 shadow-[24] p-1">
+          {/* eslint-disable-next-line jsx-a11y/alt-text */}
           <Image src={src} {...props} />
         </div>
       </Modal>


### PR DESCRIPTION
Closes #201 
Currently, image modals are way too small on mobile devices:
![image](https://github.com/user-attachments/assets/29187d6d-e318-48ce-9713-5fa736f132b1)

This PR makes it so that it takes up the majority of the width like so:
![image](https://github.com/user-attachments/assets/b14d6432-0aa3-42f6-a8ac-6dae477ad73e)
