### PR TITLE
Adjust homepage card color

### DIFF
--- a/src/components/Homepage/FightGuideComponent.js
+++ b/src/components/Homepage/FightGuideComponent.js
@@ -16,7 +16,7 @@ export default function FightGuideComponent({ entries, title, left }) {
         {entries.map((entry) => (
           <div
             key={entry.url}
-            className="bg-[#10242b] overflow-hidden rounded-lg group"
+            className="bg-[#162835] overflow-hidden rounded-lg group"
           >
             <a href={entry.url}>
               <div className="relative h-48 group-hover:brightness-75">


### PR DESCRIPTION
The color of the homepage cards has been bugging me for a bit now, I eyeballed it a bit and figured this would look a little better than the current color
Before:
![image](https://github.com/user-attachments/assets/f91ed882-1631-4b3a-91a7-d9e73fb50f37)
After:
![image](https://github.com/user-attachments/assets/c9499626-2ba6-47a9-8bd4-fbccdd11369c)

Feel free to nitpick more