### PR TITLE
Make mobile menu subitems independent of parent

### DIFF
--- a/src/components/NavBar/MobileContentAccordion.jsx
+++ b/src/components/NavBar/MobileContentAccordion.jsx
@@ -1,6 +1,6 @@
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import { Box, Collapse, List, ListItem, Typography } from "@mui/material";
+import { Box, Collapse, Typography, MenuList, MenuItem } from "@mui/material";
 import React, { useState } from "react";
 
 /**
@@ -12,20 +12,28 @@ export function MobileContentAccordion({ data, name }) {
 
   return (
     <Box sx={sx.root}>
-      <Box onClick={handleClick} sx={sx.nameContainer}>
-        <Typography>{name}</Typography>
-        {mobileOpen ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-      </Box>
+      <MenuItem onClick={handleClick}>
+        <Box sx={sx.nameContainer}>
+          <Typography>{name}</Typography>
+          {mobileOpen ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+        </Box>
+      </MenuItem>
       <Collapse in={mobileOpen} timeout="auto">
-        <List sx={sx.dropdownList}>
+        <MenuList>
           {data.map((fight, i) => (
-            <ListItem key={i} disablePadding sx={sx.dropdownItemContainer}>
-              <Box component="a" href={fight.url} sx={sx.dropdownItem}>
-                <Typography sx={sx.dropdownItemText}>{fight.title}</Typography>
+            <MenuItem
+              component="a"
+              href={fight.url}
+              key={i}
+              disablePadding
+              sx={sx.dropdownItemContainer}
+            >
+              <Box sx={sx.dropdownItem}>
+                <Typography>{fight.title}</Typography>
               </Box>
-            </ListItem>
+            </MenuItem>
           ))}
-        </List>
+        </MenuList>
       </Collapse>
     </Box>
   );
@@ -46,14 +54,10 @@ const sx = {
     width: "100%",
     cursor: "pointer",
   },
-  dropdownList: {
-    pl: 2,
-    my: 0,
-  },
   dropdownItemContainer: {
     display: "block",
     "&:hover": {
-      backgroundColor: "transparent",
+      backgroundColor: "rgba(0, 0, 0, 0.04)",
     },
   },
   dropdownItem: {
@@ -62,10 +66,6 @@ const sx = {
     display: "block",
     textDecoration: "none",
     color: "inherit",
-    "&:hover": {
-      backgroundColor: "rgba(0, 0, 0, 0.04)",
-    },
-    borderRadius: "4px",
   },
   dropdownItemText: {
     fontSize: "0.9rem",

--- a/src/components/NavBar/MobileMenu.jsx
+++ b/src/components/NavBar/MobileMenu.jsx
@@ -46,21 +46,15 @@ export function MobileMenu() {
             <Typography sx={sx.text}>Home</Typography>
           </MenuItem>
         </li>
-        <MenuItem>
-          <Box sx={sx.text}>
-            <MobileContentAccordion name="Ultimate" data={ultimateList} />
-          </Box>
-        </MenuItem>
-        <MenuItem>
-          <Box sx={sx.text}>
-            <MobileContentAccordion name="Savage" data={savageList} />
-          </Box>
-        </MenuItem>
-        <MenuItem>
-          <Box sx={sx.text}>
-            <MobileContentAccordion name="Extreme" data={extremeList} />
-          </Box>
-        </MenuItem>
+        <Box sx={sx.text}>
+          <MobileContentAccordion name="Ultimate" data={ultimateList} />
+        </Box>
+        <Box sx={sx.text}>
+          <MobileContentAccordion name="Savage" data={savageList} />
+        </Box>
+        <Box sx={sx.text}>
+          <MobileContentAccordion name="Extreme" data={extremeList} />
+        </Box>
         {/*To add when internal pages are created*/}
         {/*{pages.map((page) => (*/}
         {/*    <li key={page.name}>*/}


### PR DESCRIPTION
Closes #207 
This PR makes it so that items that are children of a section in the mobile navbar (part of the accordion) are counted as separate items in the navbar menu. This makes it so that the overall animations aren't as jarring, e.g when clicking on the parent collapsible "Ultimate", the animation doesn't propagate throughout the entire accordion. (Preview can be seen in the linked issue)