### PR TITLE
Adjust position of mobile open quick links drawer button

### DIFF
--- a/src/components/Mdx/Layout/MobileDrawer.js
+++ b/src/components/Mdx/Layout/MobileDrawer.js
@@ -22,7 +22,8 @@ function MobileDrawer({ children }) {
         sx={{
           background: "#28506E",
           ":hover": { background: "#1A3549" },
-          marginBottom: "4rem",
+          marginRight: "0.75rem",
+          marginBottom: "5.75rem",
         }}
         onClick={() => setOpen(true)}
         size="large"


### PR DESCRIPTION
Closes #211 
This PR adjusts the position of the mobile quick links drawer button slightly so that it is not cut off on mainstream mobile devices.
![image](https://github.com/user-attachments/assets/93744a9a-cb5d-47dc-aca4-f40d7d8c0a47)
