### PR TITLE
Remove Home button from Desktop

### DIFF
--- a/src/components/Layout/NavBar/DesktopMenu.jsx
+++ b/src/components/Layout/NavBar/DesktopMenu.jsx
@@ -9,14 +9,6 @@ import { ContentDropdown } from "./ContentDropdown";
 export function DesktopMenu() {
   return (
     <MenuList sx={sx.root}>
-      <li>
-        <MenuItem component="a" href="/" sx={sx.menuItem}>
-          <Typography variant="h7" component="div" sx={sx.menuItemText}>
-            Home
-          </Typography>
-        </MenuItem>
-      </li>
-
       <ContentDropdown name="Ultimate" data={ultimateList} />
       <ContentDropdown name="Savage" data={savageList} />
       <ContentDropdown name="Extreme" data={extremeList} />


### PR DESCRIPTION
After reviewing other use cases, feel it makes more sense on the mobile view to keep the Home button in the drawer
since from a user perspective, it's more ideal to have a Home button on either side of the screen depending which
hand the user's browsing with.
