### PR TITLE
Removed links to Findingway.io

### DIFF
--- a/src/components/Layout/NavBar/DesktopMenu.jsx
+++ b/src/components/Layout/NavBar/DesktopMenu.jsx
@@ -23,20 +23,6 @@ export function DesktopMenu() {
       {/*        </MenuItem>*/}
       {/*    </li>*/}
       {/*))}*/}
-
-      <li>
-        <MenuItem
-          component="a"
-          href="https://findingway.io"
-          target="_blank"
-          rel="noopener noreferrer"
-          sx={sx.menuItem}
-        >
-          <Typography variant="h7" component="div" sx={sx.menuItemText}>
-            Findingway
-          </Typography>
-        </MenuItem>
-      </li>
     </MenuList>
   );
 }

--- a/src/components/Layout/NavBar/MobileMenu.jsx
+++ b/src/components/Layout/NavBar/MobileMenu.jsx
@@ -65,17 +65,6 @@ export function MobileMenu() {
         {/*        </MenuItem>*/}
         {/*    </li>*/}
         {/*))}*/}
-        <li>
-          <MenuItem
-            onClick={handleClose}
-            component="a"
-            href="https://findingway.io"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Typography sx={sx.text}>Findingway</Typography>
-          </MenuItem>
-        </li>
       </Menu>
     </>
   );

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -110,10 +110,6 @@ export const otherList = [
     url: "https://github.com/naurffxiv/naurffxiv",
   },
   {
-    title: "Findingway.io",
-    url: "https://findingway.io",
-  },
-  {
     title: "Changelog",
     url: "/changelog",
   },


### PR DESCRIPTION
This PR removes all links to Findingway.io. It was present in the Desktop and Mobile menu, along with the footer 'Other Links'. Findingway.io isn't functional at the moment and we are likely going to fall back to using XIVPF for our data. Future development may want to add the button to link to https://xivpf.com/listings. 

Resolves #258 