### PR TITLE
Remove duplicate banner on TOP page

### DIFF
--- a/src/markdown/ultimate/top.mdx
+++ b/src/markdown/ultimate/top.mdx
@@ -10,11 +10,6 @@ order: 1
   alt="The Omega Protocol (Ultimate)"
   left
 />
-<Banner
-  src="/images/thumbnails/ultimate/top.avif"
-  alt="The Omega Protocol (Ultimate)"
-  left
-/>
 
 ## Resources by Phase
 
@@ -136,4 +131,3 @@ order: 1
 ### Helpful Macros
 
 - [TOP PF Macros](https://pastebin.com/qUJY054s)
-


### PR DESCRIPTION
This PR is a bug fix to remove the duplicate banner on the TOP page.

Resolves #260 