### PR TITLE
Fix to issue #272: Remove Patreon Link

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -102,10 +102,6 @@ export const otherList = [
     url: "https://discord.gg/naurffxiv",
   },
   {
-    title: "Support us on Patreon",
-    url: "https://patreon.com/naurffxiv",
-  },
-  {
     title: "GitHub Repository",
     url: "https://github.com/naurffxiv/naurffxiv",
   },


### PR DESCRIPTION
Kept layout of footer the same, with the removal of the Patreon link.

<img width="346" height="227" alt="Screenshot 2025-07-30 163608" src="https://github.com/user-attachments/assets/97665cf0-6c45-4780-8ad9-712ed50bd1dd" />

<img width="329" height="235" alt="image" src="https://github.com/user-attachments/assets/2b80d6f3-1e0d-41c9-8cab-89f82bf26360" />


