### PR TITLE
Fix lint-polluting file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,9 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],
   "overrides": [
     {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "files": ["*.ts", "*.tsx"],
       "rules": {
         "@typescript-eslint/explicit-function-return-type": "warn",
         "@typescript-eslint/no-explicit-any": "warn",
@@ -13,6 +14,14 @@
             "varsIgnorePattern": "^_"
           }
         ]
+      }
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unused-vars": "off"
       }
     }
   ]


### PR DESCRIPTION
resolves naurffxiv/naur#109 

This PR updates the ESLint configuration to prevent TypeScript-specific rules from applying to .js files, which caused persistent lint warnings in src/app/[difficulty]/[[...slug]]/helpers.js

Split ESLint overrides:
- .ts/.tsx files still enforce @typescript-eslint rules.
- .js/.jsx files now skip @typescript-eslint rules.
Added `"root": true` to .eslintrc.json to stop loading global ESLint configuration.
Verified helpers.js no longer reports explicit-function-return-type or no-unused-vars warnings.
