### PR TITLE
Add FRU guide to FRU resources page

### DIFF
--- a/src/markdown/ultimate/fru.mdx
+++ b/src/markdown/ultimate/fru.mdx
@@ -11,6 +11,8 @@ order: 0
   left
 />
 
+## [In-depth Guide](https://naurffxiv.com/ultimate/fru/guide)
+
 ## Resources by Phase
 
 ### P1: Fatebreaker


### PR DESCRIPTION
We're using the direct link instead of the relative as our mdx component
opens links with "https" as a separate tab. We want the in-depth guide to
be opened in a new tab rather than just redirecting to the guide.

Closes: #304
