### PR TITLE
chore(uwu): remove link to 3-3-1-1 strat.

### DIFF
--- a/src/markdown/ultimate/uwu.mdx
+++ b/src/markdown/ultimate/uwu.mdx
@@ -52,10 +52,6 @@ order: 4
   <YouTube videoId="d08-CA5zS1c" />
 </Details>
 
-<Details title="FFXIV UWU Annihilation visual guide 3-3-1-1">
-  <YouTube videoId="9eUvqv6rNT0" />
-</Details>
-
 <Details title="UwU - Ultimate Suppression Visual Guide">
   <YouTube videoId="PSrbDnFtIJ0" />
 </Details>


### PR DESCRIPTION
Closes #318.

Not much to say here - this PR removes an older strat from the page for UwU.