### PR TITLE
Fix React className warning polluting console on EX6 guide

### DIFF
--- a/src/markdown/extreme/the-windward-wilds.mdx
+++ b/src/markdown/extreme/the-windward-wilds.mdx
@@ -15,7 +15,7 @@ collapseToc: true
 
 # This page is under construction.
 
-Check out our <a href="https://discord.com/invite/naurffxiv" class="text-blue-500 underline">Discord</a> for the latest strats.
+Check out our <a href="https://discord.com/invite/naurffxiv" className="text-blue-500 underline">Discord</a> for the latest strats.
 
 <img
   src="/images/UnderConstructionMammet.avif"


### PR DESCRIPTION
**Description**

Fixes a React console warning on the Windward Wilds (Extreme) guide page by changing `class` to `className`.

**Changes**

- Replaced `class` attribute with `className` prop to remove console pollution