### PR TITLE
fix: Prevent image layout shift on cached loads

### DIFF
--- a/src/components/Mdx/Elements/Banner.js
+++ b/src/components/Mdx/Elements/Banner.js
@@ -10,7 +10,10 @@ export default function Banner({ src, alt, left = false, ...props }) {
         alt={alt}
         {...props}
         fill
-        unoptimized
+        // 'unoptimized' removed to generate aspect ratio metadata and prevent CLS.
+        // 'sizes="100vw"' ensures correct responsive sizing with 'fill'.
+        sizes="100vw"
+        priority
       />
     </div>
   );


### PR DESCRIPTION
Fixes a visual bug where banner images would briefly shrink and then expand on cached page loads. This was caused by the `unoptimized` prop preventing correct aspect ratio metadata generation.

- Removed `unoptimized `prop to enable Next.js image optimization.
- Added `sizes="100vw"` to ensure correct responsive sizing with fill.

Closes #342